### PR TITLE
chore(deps): update axios to ^1.8.2 to address vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
-    "axios": "^0.19.2",
+    "axios": "^1.8.2",
     "chart.js": "^2.9.3",
     "classnames": "^2.2.6",
     "react": "^16.13.1",


### PR DESCRIPTION
### Motivation
- Replace the vulnerable `axios@^0.19.2` dependency with a patched `1.x` release to remove known security issues in old 0.x versions.

### Description
- Updated `package.json` to set the `axios` dependency from `^0.19.2` to `^1.8.2`.

### Testing
- Ran `npm install axios@^1.8.2`, `npm audit`, and `npm ls axios`, but registry access was blocked with HTTP 403 so installs and lockfile regeneration could not complete and the locally installed package remains `0.19.2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09b7f04a4832aa2eb48182885572d)